### PR TITLE
tripperware act has roundtripper with default transport

### DIFF
--- a/tripperware.go
+++ b/tripperware.go
@@ -13,6 +13,11 @@ func (f RoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 // Tripperware represents an http client-side middleware (roundTripper middleware).
 type Tripperware func(http.RoundTripper) http.RoundTripper
 
+// RoundTrip implements RoundTripper interface
+func (t Tripperware) RoundTrip(req *http.Request) (*http.Response, error) {
+	return t(http.DefaultTransport).RoundTrip(req)
+}
+
 // DecorateClient will decorate a given http.Client with the tripperware
 // will return a clone of client if clone arg is true
 func (t Tripperware) DecorateClient(client *http.Client, clone bool) *http.Client {

--- a/tripperware_test.go
+++ b/tripperware_test.go
@@ -13,6 +13,28 @@ import (
 	"github.com/gol4ng/httpware/mocks"
 )
 
+func TestTripperware_RoundTrip(t *testing.T) {
+	req, _ := http.NewRequest("GET", "http://localhost/", nil)
+	resp := &http.Response{}
+
+	roundTripperMock := &mocks.RoundTripper{}
+	roundTripperMock.On("RoundTrip", req).Return(resp, nil)
+
+	originalDefaultTransport := http.DefaultTransport
+	http.DefaultTransport = roundTripperMock
+
+	tripper := httpware.Tripperware(func(roundTripper http.RoundTripper) http.RoundTripper {
+		assert.Equal(t, http.DefaultTransport, roundTripper)
+		return roundTripper
+	})
+
+	r, err := tripper.RoundTrip(req)
+	assert.Nil(t, err)
+	assert.Equal(t, r, resp)
+
+	http.DefaultTransport = originalDefaultTransport
+}
+
 func TestTripperware_DecorateClient(t *testing.T) {
 	req, _ := http.NewRequest("GET", "http://localhost/", nil)
 	resp := &http.Response{}


### PR DESCRIPTION
Simplify usage when you want to use as RoundTripper

```
// New short syntax
&http.Client{
	Transport: tripperware.Metrics(config)
}
​
// long version
&http.Client{
	Transport: tripperware.Metrics(config)(http.DefaultTransport)
}
```