### PR TITLE
Revert stack computation

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -25,8 +25,9 @@ type Middlewares []Middleware
 
 // DecorateHandler will decorate a given http.Handler with the given middlewares created by MiddlewareStack()
 func (m Middlewares) DecorateHandler(handler http.Handler) http.Handler {
-	for _, middleware := range m {
-		handler = middleware(handler)
+	mLen := len(m)
+	for i := mLen - 1; i >= 0; i-- {
+		handler = m[i](handler)
 	}
 	return handler
 }

--- a/middleware.go
+++ b/middleware.go
@@ -8,19 +8,19 @@ type Middleware func(http.Handler) http.Handler
 
 // Append will add given middlewares after existing one
 // t1.Append(t2, t3) => [t1, t2, t3]
-// t1.Append(t2, t3).DecorateHandler(<yourHandler>) == t3(t2(t1(<yourHandler>)))
+// t1.Append(t2, t3).DecorateHandler(<yourHandler>) == t1(t2(t3(<yourHandler>)))
 func (m Middleware) Append(middlewares ...Middleware) Middlewares {
 	return append([]Middleware{m}, middlewares...)
 }
 
 // Prepend will add given middlewares before existing one
 // t1.Prepend(t2, t3) => [t2, t3, t1]
-// t1.Prepend(t2, t3).DecorateHandler(<yourHandler>) == t1(t3(t2(<yourHandler>)))
+// t1.Prepend(t2, t3).DecorateHandler(<yourHandler>) == t2(t3(t1(<yourHandler>)))
 func (m Middleware) Prepend(middlewares ...Middleware) Middlewares {
 	return append(middlewares, m)
 }
 
-// [t1, t2, t3].DecorateHandler(<yourHandler>) == t3(t2(t1(<yourHandler>)))
+// [t1, t2, t3].DecorateHandler(<yourHandler>) == t1(t2(t3(<yourHandler>)))
 type Middlewares []Middleware
 
 // DecorateHandler will decorate a given http.Handler with the given middlewares created by MiddlewareStack()
@@ -38,14 +38,14 @@ func (m Middlewares) DecorateHandlerFunc(handler http.HandlerFunc) http.Handler 
 
 // Append will add given middleware after existing one
 // [t1, t2].Append(t3, t4) => [t1, t2, t3, t4]
-// [t1, t2].Append(t3, t4).DecorateHandler(<yourHandler>) == t4(t3(t2(t1(<yourHandler>))))
+// [t1, t2].Append(t3, t4).DecorateHandler(<yourHandler>) == t1(t2(t3(t4(<yourHandler>))))
 func (m Middlewares) Append(middleware ...Middleware) Middlewares {
 	return append(m, middleware...)
 }
 
 // Prepend will add given middleware before existing one
 // [t1, t2].Prepend(t3, t4) => [t3, t4, t1, t2]
-// [t1, t2].Prepend(t3, t4).DecorateHandler(<yourHandler>) == t2(t1(t4(t3(<yourHandler>))))
+// [t1, t2].Prepend(t3, t4).DecorateHandler(<yourHandler>) == t3(t4(t1(t2(<yourHandler>))))
 func (m Middlewares) Prepend(middleware ...Middleware) Middlewares {
 	return append(middleware, m...)
 }

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -41,12 +41,12 @@ func TestMiddleware_Append(t *testing.T) {
 		_, _ = w.Write([]byte(responseBody))
 	})
 
-	middleware := getMiddleware(t, i, 2, 4)
+	middleware := getMiddleware(t, i, 0, 6)
 
 	middleware.Append(
 		// the middleware will be add here
 		getMiddleware(t, i, 1, 5),
-		getMiddleware(t, i, 0, 6),
+		getMiddleware(t, i, 2, 4),
 	).DecorateHandler(handler).ServeHTTP(responseWriterMock, req)
 }
 
@@ -66,10 +66,10 @@ func TestMiddleware_Prepend(t *testing.T) {
 		_, _ = w.Write([]byte(responseBody))
 	})
 
-	middleware := getMiddleware(t, i, 0, 6)
+	middleware := getMiddleware(t, i, 2, 4)
 
 	middleware.Prepend(
-		getMiddleware(t, i, 2, 4),
+		getMiddleware(t, i, 0, 6),
 		getMiddleware(t, i, 1, 5),
 		// the middleware will be add here
 	).DecorateHandler(handler).ServeHTTP(responseWriterMock, req)
@@ -142,14 +142,14 @@ func TestMiddlewares_Append(t *testing.T) {
 	})
 
 	middlewares := httpware.MiddlewareStack(
-		getMiddleware(t, i, 3, 5),
-		getMiddleware(t, i, 2, 6),
+		getMiddleware(t, i, 0, 8),
+		getMiddleware(t, i, 1, 7),
 	)
 
 	middlewares.Append(
 		// the middlewares will be add here
-		getMiddleware(t, i, 1, 7),
-		getMiddleware(t, i, 0, 8),
+		getMiddleware(t, i, 2, 6),
+		getMiddleware(t, i, 3, 5),
 	).DecorateHandler(handler).ServeHTTP(responseWriterMock, req)
 }
 
@@ -170,13 +170,13 @@ func TestMiddlewares_Prepend(t *testing.T) {
 	})
 
 	middlewares := httpware.MiddlewareStack(
-		getMiddleware(t, i, 1, 7),
-		getMiddleware(t, i, 0, 8),
+		getMiddleware(t, i, 2, 6),
+		getMiddleware(t, i, 3, 5),
 	)
 
 	middlewares.Prepend(
-		getMiddleware(t, i, 3, 5),
-		getMiddleware(t, i, 2, 6),
+		getMiddleware(t, i, 0, 8),
+		getMiddleware(t, i, 1, 7),
 		// the middlewares will be add here
 	).DecorateHandler(handler).ServeHTTP(responseWriterMock, req)
 }
@@ -202,8 +202,8 @@ func ExampleMiddlewareStack() {
 	}
 	// create the middleware stack
 	stack := httpware.MiddlewareStack(
-		logResponseHeaders,
 		addCustomResponseHeader,
+		logResponseHeaders,
 	)
 	// create a server
 	srv := http.NewServeMux()

--- a/tripperware.go
+++ b/tripperware.go
@@ -37,19 +37,19 @@ func (t Tripperware) DecorateClient(client *http.Client, clone bool) *http.Clien
 
 // Append will add given tripperwares after existing one
 // t1.Append(t2, t3) == [t1, t2, t3]
-// t1.Append(t2, t3).DecorateRoundTripper(<yourTripper>) == t3(t2(t1(<yourTripper>)))
+// t1.Append(t2, t3).DecorateRoundTripper(<yourTripper>) == t1(t2(t3(<yourTripper>)))
 func (t Tripperware) Append(tripperwares ...Tripperware) Tripperwares {
 	return append([]Tripperware{t}, tripperwares...)
 }
 
 // Prepend will add given tripperwares before existing one
 // t1.Prepend(t2, t3) => [t2, t3, t1]
-// t1.Prepend(t2, t3).DecorateRoundTripper(<yourTripper>) == t1(t3(t2(<yourTripper>)))
+// t1.Prepend(t2, t3).DecorateRoundTripper(<yourTripper>) == t2(t3(t1(<yourTripper>)))
 func (t Tripperware) Prepend(tripperwares ...Tripperware) Tripperwares {
 	return append(tripperwares, t)
 }
 
-// [t1, t2, t3].DecorateRoundTripper(roundTripper) == t3(t2(t1(roundTripper)))
+// [t1, t2, t3].DecorateRoundTripper(roundTripper) == t1(t2(t3(roundTripper)))
 type Tripperwares []Tripperware
 
 // RoundTrip implements RoundTripper interface
@@ -94,14 +94,14 @@ func (t Tripperwares) DecorateRoundTripFunc(tripper RoundTripFunc) http.RoundTri
 
 // Append will add given tripperwares after existing one
 // [t1, t2].Append(t3, t4) == [t1, t2, t3, t4]
-// [t1, t2].Append(t3, t4).DecorateRoundTripper(<yourTripper>) == t4(t3(t2(t1(<yourTripper>))))
+// [t1, t2].Append(t3, t4).DecorateRoundTripper(<yourTripper>) == t1(t2(t3(t4(<yourTripper>))))
 func (t Tripperwares) Append(tripperwares ...Tripperware) Tripperwares {
 	return append(t, tripperwares...)
 }
 
 // Prepend will add given tripperwares before existing one
 // [t1, t2].Prepend(t3, t4) == [t3, t4, t1, t2]
-// [t1, t2].Prepend(t3, t4).DecorateRoundTripper(<yourTripper>) == t2(t1(t4(t3(<yourTripper>))))
+// [t1, t2].Prepend(t3, t4).DecorateRoundTripper(<yourTripper>) == t3(t4(t1(t2(<yourTripper>))))
 func (t Tripperwares) Prepend(tripperwares ...Tripperware) Tripperwares {
 	return append(tripperwares, t...)
 }

--- a/tripperware.go
+++ b/tripperware.go
@@ -1,6 +1,8 @@
 package httpware
 
-import "net/http"
+import (
+	"net/http"
+)
 
 // RoundTripFunc wraps a func to make it into an http.RoundTripper. Similar to http.HandleFunc.
 type RoundTripFunc func(*http.Request) (*http.Response, error)
@@ -78,8 +80,9 @@ func (t Tripperwares) DecorateRoundTripper(tripper http.RoundTripper) http.Round
 	if tripper == nil {
 		tripper = http.DefaultTransport
 	}
-	for _, tripperware := range t {
-		tripper = tripperware(tripper)
+	tLen := len(t)
+	for i := tLen - 1; i >= 0; i-- {
+		tripper = t[i](tripper)
 	}
 	return tripper
 }

--- a/tripperware_test.go
+++ b/tripperware_test.go
@@ -331,9 +331,9 @@ func TestTripperwares_Prepend(t *testing.T) {
 	)
 
 	r, err := trippers.Prepend(
-		// the tripper will be add here
 		getTripper(t, i, 3, 5),
 		getTripper(t, i, 2, 6),
+		// the tripper will be add here
 	).DecorateRoundTripper(roundTripperMock).RoundTrip(req)
 
 	assert.Nil(t, err)

--- a/tripperware_test.go
+++ b/tripperware_test.go
@@ -119,12 +119,12 @@ func TestTripperware_Append(t *testing.T) {
 		return resp, nil
 	})
 
-	tripper := getTripper(t, i, 2, 4)
+	tripper := getTripper(t, i, 0, 6)
 
 	r, err := tripper.Append(
 		// the tripper will be add here
 		getTripper(t, i, 1, 5),
-		getTripper(t, i, 0, 6),
+		getTripper(t, i, 2, 4),
 	).DecorateRoundTripper(roundTripperMock).RoundTrip(req)
 
 	assert.Nil(t, err)
@@ -143,10 +143,10 @@ func TestTripperware_Prepend(t *testing.T) {
 		return resp, nil
 	})
 
-	tripper := getTripper(t, i, 0, 6)
+	tripper := getTripper(t, i, 2, 4)
 
 	r, err := tripper.Prepend(
-		getTripper(t, i, 2, 4),
+		getTripper(t, i, 0, 6),
 		getTripper(t, i, 1, 5),
 		// the tripper will be add here
 	).DecorateRoundTripper(roundTripperMock).RoundTrip(req)
@@ -299,14 +299,14 @@ func TestTripperwares_Append(t *testing.T) {
 	})
 
 	trippers := httpware.TripperwareStack(
-		getTripper(t, i, 3, 5),
-		getTripper(t, i, 2, 6),
+		getTripper(t, i, 0, 8),
+		getTripper(t, i, 1, 7),
 	)
 
 	r, err := trippers.Append(
 		// the tripper will be add here
-		getTripper(t, i, 1, 7),
-		getTripper(t, i, 0, 8),
+		getTripper(t, i, 2, 6),
+		getTripper(t, i, 3, 5),
 	).DecorateRoundTripper(roundTripperMock).RoundTrip(req)
 
 	assert.Nil(t, err)
@@ -326,13 +326,13 @@ func TestTripperwares_Prepend(t *testing.T) {
 	})
 
 	trippers := httpware.TripperwareStack(
-		getTripper(t, i, 1, 7),
-		getTripper(t, i, 0, 8),
+		getTripper(t, i, 2, 6),
+		getTripper(t, i, 3, 5),
 	)
 
 	r, err := trippers.Prepend(
-		getTripper(t, i, 3, 5),
-		getTripper(t, i, 2, 6),
+		getTripper(t, i, 0, 8),
+		getTripper(t, i, 1, 7),
 		// the tripper will be add here
 	).DecorateRoundTripper(roundTripperMock).RoundTrip(req)
 
@@ -364,8 +364,8 @@ func ExampleTripperwareStack_WithDefaultTransport() {
 	// /!\ note that the tripperware order is important here
 	// each request will pass through `addCustomRequestHeader` before `logRequestHeaders`
 	stack := httpware.TripperwareStack(
-		logRequestHeaders,
 		addCustomRequestHeader,
+		logRequestHeaders,
 	)
 	// create http client using the tripperwareStack as RoundTripper
 	client := http.Client{
@@ -398,8 +398,8 @@ func ExampleTripperwareStack_WithCustomTransport() {
 	// /!\ note that the tripperware order is important here
 	// each request will pass through `addCustomRequestHeader` before `logRequestHeaders`
 	stack := httpware.TripperwareStack(
-		logRequestHeaders,
 		addCustomRequestHeader,
+		logRequestHeaders,
 	)
 
 	// http.Transport implements RoundTripper interface

--- a/tripperware_test.go
+++ b/tripperware_test.go
@@ -331,9 +331,9 @@ func TestTripperwares_Prepend(t *testing.T) {
 	)
 
 	r, err := trippers.Prepend(
+		// the tripper will be add here
 		getTripper(t, i, 3, 5),
 		getTripper(t, i, 2, 6),
-		// the tripper will be add here
 	).DecorateRoundTripper(roundTripperMock).RoundTrip(req)
 
 	assert.Nil(t, err)


### PR DESCRIPTION
## ⚠️ This is a Breaking change ⚠️ 

### Change
invert the stack computation:
**middleware**
`[t1, t2, t3, t4].DecorateHandler(<yourHandler>) == t4(t3(t2(t1(<yourHandler>))))`
_becomes_
`[t1, t2, t3, t4].DecorateHandler(<yourHandler>) == t1(t2(t3(t4(<yourHandler>))))`

**tripperware**
`[t1, t2, t3, t4].DecorateRoundTripper(<yourTripper>) == t4(t3(t2(t1(<yourTripper>))))`
_become_
`[t1, t2, t3, t4].DecorateRoundTripper(<yourTripper>) == t1(t2(t3(t4(<yourTripper>))))`

### Migration note

In order to correctly update version you must invert all your stack order
Example:
```go
stack := httpware.TripperwareStack(
	MyTripperwareA,
	MyTripperwareB,
)
stack.Append(
	MyTripperwareC, 
	MyTripperwareD,
)
// MyTripperwareD(MyTripperwareC(MyTripperwareB(MyTripperwareA(<yourtripper>))))
```
_becomes_
```go
stack := httpware.TripperwareStack(
	MyTripperwareB,
	MyTripperwareA,
)
stack.Prepend(
	MyTripperwareD,
	MyTripperwareC,
)
// MyTripperwareD(MyTripperwareC(MyTripperwareB(MyTripperwareA(<yourtripper>))))
```