### PR TITLE
Rework response writer interceptor

### DIFF
--- a/middleware/correlation_id_test.go
+++ b/middleware/correlation_id_test.go
@@ -64,7 +64,11 @@ func ExampleCorrelationId() {
 	}()
 
 	resp, err := http.Get("http://localhost" + port)
-	fmt.Printf("%s: %v %v\n", "my-personal-header-name", resp.Header.Get("my-personal-header-name"), err)
+	if resp != nil {
+		fmt.Println(err)
+	} else {
+		fmt.Printf("%s: %v\n", "my-personal-header-name", resp.Header.Get("my-personal-header-name"))
+	}
 
-	//Output: my-personal-header-name: my-fixed-request-id <nil>
+	//Output: my-personal-header-name: my-fixed-request-id
 }

--- a/middleware/correlation_id_test.go
+++ b/middleware/correlation_id_test.go
@@ -64,9 +64,9 @@ func ExampleCorrelationId() {
 	}()
 
 	resp, err := http.Get("http://localhost" + port)
-	if resp != nil {
+	if err != nil {
 		fmt.Println(err)
-	} else {
+	} else if resp != nil {
 		fmt.Printf("%s: %v\n", "my-personal-header-name", resp.Header.Get("my-personal-header-name"))
 	}
 

--- a/middleware/enable_test.go
+++ b/middleware/enable_test.go
@@ -2,6 +2,8 @@ package middleware_test
 
 import (
 	"fmt"
+	"log"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -57,7 +59,11 @@ func TestEnable(t *testing.T) {
 // =====================================================================================================================
 
 func ExampleEnable() {
-	port := ":9104"
+	// Example Need a random ephemeral port (to have a free port)
+	ln, err := net.Listen("tcp", ":0")
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	enableDummyMiddleware := true // or false
 	dummyMiddleware := func(next http.Handler) http.Handler {
@@ -71,18 +77,18 @@ func ExampleEnable() {
 	)
 
 	// create a server in order to show it work
-	srv := http.NewServeMux()
-	srv.HandleFunc("/", func(writer http.ResponseWriter, request *http.Request) {
-		fmt.Println("server receive request with request:", request.Header.Get("FakeHeader"))
-	})
-
+	srv := &http.Server{
+		Handler: stack.DecorateHandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			fmt.Println("server receive request with request:", request.Header.Get("FakeHeader"))
+		}),
+	}
 	go func() {
-		if err := http.ListenAndServe(port, stack.DecorateHandler(srv)); err != nil {
+		if err := srv.Serve(ln); err != nil {
 			panic(err)
 		}
 	}()
 
-	_, _ = http.Get("http://localhost" + port + "/")
+	_, _ = http.Get("http://" + ln.Addr().String())
 
 	// Output:
 	//server receive request with request: this header is set when not /home url

--- a/middleware/interceptor.go
+++ b/middleware/interceptor.go
@@ -12,7 +12,10 @@ func Interceptor(options ...InterceptorOption) httpware.Middleware {
 	config := NewInterceptorConfig(options...)
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(writer http.ResponseWriter, req *http.Request) {
-			writerInterceptor := NewResponseWriterInterceptor(writer)
+			writerInterceptor, ok := writer.(*ResponseWriterInterceptor)
+			if !ok {
+				writerInterceptor = NewResponseWriterInterceptor(writer)
+			}
 
 			req.Body = interceptor.NewCopyReadCloser(req.Body)
 			config.CallbackBefore(writerInterceptor, req)

--- a/middleware/metrics.go
+++ b/middleware/metrics.go
@@ -14,7 +14,10 @@ func Metrics(recorder metrics.Recorder, options ... metrics.Option) httpware.Mid
 	config := metrics.NewConfig(recorder, options...)
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(writer http.ResponseWriter, req *http.Request) {
-			writerInterceptor := NewResponseWriterInterceptor(writer)
+			writerInterceptor, ok := writer.(*ResponseWriterInterceptor)
+			if !ok {
+				writerInterceptor = NewResponseWriterInterceptor(writer)
+			}
 			handlerName := config.IdentifierProvider(req)
 			if config.MeasureInflightRequests {
 				config.Recorder.AddInflightRequests(req.Context(), handlerName, 1)


### PR DESCRIPTION
It allow sharing of ResponseWriterInterceptor in the middleware stack (in order to not RE encapsulate it)